### PR TITLE
fix: TACC Permissions Issue

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,16 +1,13 @@
 #!/bin/bash
 
-set -xe
-echo "Run ElmFire"
-
 pwd
 env
-ls -l /
-ls -l /elmfire
-ls -l /elmfire/elmfire
+ls -ld ${ELMFIRE_BASE_DIR}
 
-cd $ELMFIRE_BASE_DIR/tutorials/01-constant-wind
+cp $ELMFIRE_BASE_DIR ${_tapisExecSystemExecDir}
+ls -ld ${_tapisExecSystemExecDir}
+cd ${_tapisExecSystemExecDir}
 ./01-run.sh
 
-ls 
-cp -r outputs $SCRATCH
+ls
+cp -r outputs ${_tapisExecSystemOutputDir}

--- a/run.sh
+++ b/run.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 
+set -xe
 echo "Run ElmFire"
+
+env
+ls -l /
+ls -l /elmfire
+ls -l /elmfire/elmfire
 
 cd $ELMFIRE_BASE_DIR/tutorials/01-constant-wind
 ./01-run.sh

--- a/run.sh
+++ b/run.sh
@@ -6,7 +6,7 @@ ls -ld ${ELMFIRE_BASE_DIR}
 
 cp -r ${ELMFIRE_BASE_DIR} ${_tapisExecSystemExecDir}
 ls -ld ${_tapisExecSystemExecDir}
-cd ${_tapisExecSystemExecDir}/${ELMFIRE_BASE_DIR}
+cd ${_tapisExecSystemExecDir}/elmfire
 ./01-run.sh
 
 ls

--- a/run.sh
+++ b/run.sh
@@ -4,9 +4,9 @@ pwd
 env
 ls -ld ${ELMFIRE_BASE_DIR}
 
-cp $ELMFIRE_BASE_DIR ${_tapisExecSystemExecDir}
+cp -r ${ELMFIRE_BASE_DIR} ${_tapisExecSystemExecDir}
 ls -ld ${_tapisExecSystemExecDir}
-cd ${_tapisExecSystemExecDir}
+cd ${_tapisExecSystemExecDir}/${ELMFIRE_BASE_DIR}
 ./01-run.sh
 
 ls

--- a/run.sh
+++ b/run.sh
@@ -6,7 +6,7 @@ ls -ld ${ELMFIRE_BASE_DIR}
 
 cp -r ${ELMFIRE_BASE_DIR} ${_tapisExecSystemExecDir}
 ls -ld ${_tapisExecSystemExecDir}
-cd ${_tapisExecSystemExecDir}/elmfire
+cd ${_tapisExecSystemExecDir}/elmfire/tutorials/01-constant-wind
 ./01-run.sh
 
 ls

--- a/run.sh
+++ b/run.sh
@@ -3,6 +3,7 @@
 set -xe
 echo "Run ElmFire"
 
+pwd
 env
 ls -l /
 ls -l /elmfire


### PR DESCRIPTION
When running ELMFIRE on TACC, users cannot write directly to the ${ELMFIRE_BASE_DIR} directory because TACC containers run as a regular user, not as root. This PR fixes this issue by implementing a proper file copying mechanism.
The key change is to copy files into _tapisExecSystemExecDir where the user has write permissions, rather than trying to write directly to ${ELMFIRE_BASE_DIR}.
This change allows ELMFIRE to run properly on TACC without permission issues, following the same pattern shown in the existing run.sh script.